### PR TITLE
map-type attribute can be used on HashMap instances inside DSL. 

### DIFF
--- a/src/hex/compiler/factory/HashMapFactory.hx
+++ b/src/hex/compiler/factory/HashMapFactory.hx
@@ -51,6 +51,20 @@ class HashMapFactory
 					Context.warning( "HashMapFactory.build() adds item with a 'null' key for '"  + item.value +"' value.", constructorVO.filePosition );
 				}
 			}
+			
+			if ( constructorVO.mapTypes != null )
+			{
+				var mapTypes = constructorVO.mapTypes;
+				for ( mapType in mapTypes )
+				{
+					var classToMap = MacroUtil.getPack( mapType, constructorVO.filePosition );
+					factoryVO.expressions.push
+					( 
+						macro @:pos( constructorVO.filePosition ) 
+							@:mergeBlock { __applicationContextInjector.mapToValue( $p { classToMap }, $extVar, $v { idVar } ); } 
+					);
+				}
+			}
 		}
 		
 		return e;

--- a/src/hex/ioc/control/HashMapFactory.hx
+++ b/src/hex/ioc/control/HashMapFactory.hx
@@ -43,6 +43,16 @@ class HashMapFactory
 					trace( "HashMapFactory.build() adds item with a 'null' key for '"  + item.value +"' value." );
 				}
 			}
+			
+			if ( constructorVO.mapTypes != null )
+			{
+				var mapTypes = constructorVO.mapTypes;
+				for ( mapType in mapTypes )
+				{
+					var classToMap : Class<Dynamic> = Type.resolveClass( mapType );
+					factoryVO.contextFactory.getApplicationContext().getInjector().mapToValue( classToMap, map, constructorVO.ID );
+				}
+			}
 		}
 
 		constructorVO.result = map;

--- a/test/context/hashmapWithMapType.xml
+++ b/test/context/hashmapWithMapType.xml
@@ -1,0 +1,8 @@
+<root name="applicationContext">
+    <collection id="fruits" type="hex.collection.HashMap" map-type="hex.collection.HashMap">
+        <item> <key value="0"/> <value ref="fruit0"/></item>
+        <item> <key value="1"/> <value ref="fruit1"/></item>
+    </collection>
+    <fruit id="fruit0" type="hex.ioc.parser.xml.mock.MockFruitVO"><argument value="orange"/></fruit>
+    <fruit id="fruit1" type="hex.ioc.parser.xml.mock.MockFruitVO"><argument value="apple"/></fruit>
+</root>

--- a/test/hex/compiler/parser/xml/XmlCompilerTest.hx
+++ b/test/hex/compiler/parser/xml/XmlCompilerTest.hx
@@ -453,6 +453,24 @@ class XmlCompilerTest
 		Assert.equals( "banana", banana.toString(), "" );
 	}
 	
+	@Test( "test building HashMap with map-type" )
+	public function testBuildingHashMapWithMapType() : Void
+	{
+		this._applicationAssembler = XmlCompiler.readXmlFile( "context/hashmapWithMapType.xml" );
+
+		var fruits : HashMap<Dynamic, MockFruitVO> = this._getCoreFactory().locate( "fruits" );
+		Assert.isNotNull( fruits, "" );
+
+		var orange 	: MockFruitVO = fruits.get( '0' );
+		var apple 	: MockFruitVO = fruits.get( '1' );
+
+		Assert.equals( "orange", orange.toString(), "" );
+		Assert.equals( "apple", apple.toString(), "" );
+		
+		var map = this._getCoreFactory().getInjector().getInstance( HashMap, "fruits" );
+		Assert.equals( fruits, map );
+	}
+	
 	@Test( "test building two modules listening each other" )
 	public function testBuildingTwoModulesListeningEachOther() : Void
 	{

--- a/test/hex/ioc/parser/xml/ObjectXMLParserTest.hx
+++ b/test/hex/ioc/parser/xml/ObjectXMLParserTest.hx
@@ -419,6 +419,24 @@ class ObjectXMLParserTest
 		Assert.equals( "banana", banana.toString(), "" );
 	}
 	
+	@Test( "test building HashMap with map-type" )
+	public function testBuildingHashMapWithMapType() : Void
+	{
+		this.build( XmlReader.getXml( "context/hashmapWithMapType.xml" ) );
+
+		var fruits : HashMap<Dynamic, MockFruitVO> = this._builderFactory.getCoreFactory().locate( "fruits" );
+		Assert.isNotNull( fruits, "" );
+
+		var orange 	: MockFruitVO = fruits.get( '0' );
+		var apple 	: MockFruitVO = fruits.get( '1' );
+
+		Assert.equals( "orange", orange.toString(), "" );
+		Assert.equals( "apple", apple.toString(), "" );
+		
+		var map = this._builderFactory.getCoreFactory().getInjector().getInstance( HashMap, "fruits" );
+		Assert.equals( fruits, map );
+	}
+	
 	@Test( "test building two modules listening each other" )
 	public function testBuildingTwoModulesListeningEachOther() : Void
 	{


### PR DESCRIPTION
This closes DoclerLabs/hexMachina#86
