### PR TITLE
Use Reflect.getProperty.

### DIFF
--- a/src/hex/util/FastEval.hx
+++ b/src/hex/util/FastEval.hx
@@ -23,7 +23,7 @@ class FastEval
 		while ( members.length > 0 )
 		{
 			var member : String = members.shift();
-			result = Reflect.field( target, member );
+			result = Reflect.getProperty( target, member );
 			
 			if ( result == null )
 			{


### PR DESCRIPTION
This fixes an issue with the runtime DSL not being able to access properties correctly.